### PR TITLE
Justify nginx proxy settings to make port mappings support using the host port other than 80.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ If the environment variable "SUPERVISED" is set to true, the container won't be 
 
 ```conf
 server.port_mappings = 80:80,443:443
+server.port_mappings = XXXX:80,XXXX:443
 ```
 
 #### Let's encrypt SSL certificate

--- a/templates/seafile.nginx.conf.template
+++ b/templates/seafile.nginx.conf.template
@@ -33,7 +33,7 @@ server {
     location / {
         proxy_pass http://127.0.0.1:8000/;
         proxy_read_timeout 310s;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header Forwarded "for=$remote_addr;proto=$scheme";
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Refer to #15 