### PR TITLE
Allow acme routes on port 80, so certbot renewal will not fail

### DIFF
--- a/image/seafile/templates/seafile.nginx.conf.template
+++ b/image/seafile/templates/seafile.nginx.conf.template
@@ -4,7 +4,17 @@
 server {
     listen 80;
     server_name _ default_server;
-    rewrite ^ https://{{ domain }}$request_uri? permanent;
+
+    # allow certbot to connect to challenge location via HTTP Port 80
+    # otherwise renewal request will fail
+    location /.well-known/acme-challenge/ {
+        alias /var/www/challenges/;
+        try_files $uri =404;
+    }
+
+    location / {
+        rewrite ^ https://{{ domain }}$request_uri? permanent;
+    }
 }
 {% endif -%}
 


### PR DESCRIPTION
Previous to this patch, certbot cron jobs failed.

It was not possible to download the requested challenge via HTTP (80), because all requests were redirected to HTTPS (443).

See log:

```
root@seafile:/opt/seafile# /scripts/ssl.sh /shared/ssl seafile.host.com
remote: Counting objects: 4, done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 4 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
From git://github.com/diafygi/acme-tiny
   ad7802f..5350420  master     -> master
 * [new tag]         4.0.4      -> 4.0.4
   ad7802f..5350420  master     -> origin/master
warning: fetch updated the current branch head.
fast-forwarding your working tree from
commit ad7802f1c47e5c31a8e7dfedb3577e6c7d04844a.
Already up-to-date.
Parsing account key...
Parsing CSR...
Found domains: seafile.host.com
Getting directory...
Directory found!
Registering account...
Already registered!
Creating new order...
Order created!
Verifying seafile.feinarbyte.de...
Traceback (most recent call last):
  File "/shared/ssl/letsencrypt/acme_tiny.py", line 198, in <module>
    main(sys.argv[1:])
  File "/shared/ssl/letsencrypt/acme_tiny.py", line 194, in main
    signed_crt = get_crt(args.account_key, args.csr, args.acme_dir, log=LOGGER, CA=args.ca, disable_check=args.disable_check, directory_url=args.directory_url, contact=args.contact)
  File "/shared/ssl/letsencrypt/acme_tiny.py", line 144, in get_crt
    raise ValueError("Wrote file to {0}, but couldn't download {1}: {2}".format(wellknown_path, wellknown_url, e))
ValueError: Wrote file to /var/www/challenges/x-M2XQnAJ01bdKPQrqNqRBI1W5oxAqtFMrdR6UQLUG8, but couldn't download http://seafile.feinarbyte.de/.well-known/acme-challenge/x-M2XQnAJ01bdKPQrqNqRBI1W5oxAqtFMrdR6UQLUG8: Error:
Url: http://seafile.feinarbyte.de/.well-known/acme-challenge/x-M2XQnAJ01bdKPQrqNqRBI1W5oxAqtFMrdR6UQLUG8
```