### PR TITLE
Allow custom nginx configuration

### DIFF
--- a/README.pro.md
+++ b/README.pro.md
@@ -106,7 +106,7 @@ When building the docker container, use:
 
 ```
 -e SEAFILE_SERVER_NGINX_CONF_CUSTOM=true
--v <local path to seafile.nginx.conf>:/etc/nginx/sites-enabled/nginx.seafile.conf
+-v <local folder path>:/etc/nginx/sites-enabled
 ```
 
 #### Find logs

--- a/README.pro.md
+++ b/README.pro.md
@@ -100,6 +100,13 @@ After modification, you need to restart the container:
 docker restart seafile
 ```
 
+#### Modify Nginx Server Configurations
+
+When building the docker container, use:
+
+-e SEAFILE_SERVER_NGINX_CONF_CUSTOM=true
+-v <local path to seafile.nginx.conf>:/etc/nginx/sites-enabled/nginx.seafile.conf
+
 #### Find logs
 
 The seafile logs are under `/shared/logs/seafile` in the docker, or `/opt/seafile-data/logs/seafile` in the server that run the docker.

--- a/README.pro.md
+++ b/README.pro.md
@@ -104,8 +104,10 @@ docker restart seafile
 
 When building the docker container, use:
 
+```
 -e SEAFILE_SERVER_NGINX_CONF_CUSTOM=true
 -v <local path to seafile.nginx.conf>:/etc/nginx/sites-enabled/nginx.seafile.conf
+```
 
 #### Find logs
 

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -72,7 +72,12 @@ def init_letsencrypt():
 
 
 def generate_local_nginx_conf():
-    # Now create the final nginx configuratin
+    custom = get_conf('SEAFILE_SERVER_NGINX_CONF_CUSTOM', 'false')
+    
+    if custom:
+        return
+    
+    # Now create the final nginx configuration
     domain = get_conf('SEAFILE_SERVER_HOSTNAME', 'seafile.example.com')
     context = {
         'https': is_https(),


### PR DESCRIPTION
allow to use a custom nginx config file

building the docker container with:

-v <local path>/nginx.seafile.conf:/etc/nginx/sites-enabled/nginx.seafile.conf
-e SEAFILE_SERVER_NGINX_CONF_CUSTOM=1