### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 language: python
 
+python: 2.7
+
 services:
   - docker
 


### PR DESCRIPTION
Travis is now defaulting to Python 3 which seems to break the test sequence.

This small PR just forces Travis to use Python 2.7 while the real issue with using Python 3 can be investigated.