### PR TITLE
Delete bundled ldap libs which conflict with the base image

### DIFF
--- a/image/pro_seafile/Dockerfile
+++ b/image/pro_seafile/Dockerfile
@@ -10,6 +10,9 @@ RUN mkdir -p /opt/seafile/
 RUN curl -sSL -G -d "p=/pro/seafile-pro-server_${SEAFILE_VERSION}_x86-64_Ubuntu.tar.gz&dl=1" https://download.seafile.com/d/6e5297246c/files/ \
     | tar xzf - -C /opt/seafile/
 
+# remove bundled ldap libs that conflict with base image
+RUN find /opt/seafile \( -name "liblber-*" -o -name "libldap-*" -o -name "libldap_r*" \) -delete
+
 ADD scripts/create_data_links.sh /etc/my_init.d/01_create_data_links.sh
 
 COPY scripts /scripts

--- a/image/seafile/Dockerfile
+++ b/image/seafile/Dockerfile
@@ -9,6 +9,9 @@ RUN mkdir -p /opt/seafile/ && \
     curl -sSL -o - https://download.seadrive.org/seafile-server_${SEAFILE_VERSION}_x86-64.tar.gz \
     | tar xzf - -C /opt/seafile/
 
+# remove bundled ldap libs that conflict with base image
+RUN find /opt/seafile \( -name "liblber-*" -o -name "libldap-*" -o -name "libldap_r*" \) -delete
+
 ADD scripts/create_data_links.sh /etc/my_init.d/01_create_data_links.sh
 
 COPY scripts /scripts


### PR DESCRIPTION
Delete the ldap libaries which come with the bundled seafile.tar.gz. Those conflict with the one provided base image. The result is that ldaps won't work.