### PR TITLE
Allow connection to the Seafile db user from '%'

### DIFF
--- a/scripts_7.1/bootstrap.py
+++ b/scripts_7.1/bootstrap.py
@@ -124,7 +124,7 @@ def init_seafile_server():
         'SERVER_IP': get_conf('SEAFILE_SERVER_HOSTNAME', 'seafile.example.com'),
         'MYSQL_USER': 'seafile',
         'MYSQL_USER_PASSWD': str(uuid.uuid4()),
-        'MYSQL_USER_HOST': '%.%.%.%',
+        'MYSQL_USER_HOST': '%',
         'MYSQL_HOST': get_conf('DB_HOST','127.0.0.1'),
         # Default MariaDB root user has empty password and can only connect from localhost.
         'MYSQL_ROOT_PASSWD': get_conf('DB_ROOT_PASSWD', ''),


### PR DESCRIPTION
Currently the bootstrap script creates a seafile user with the following Host: `%.%.%.%`.

This leads to denied access if the database is accessed over IPv6. Instead, use `%` which is the most generic wildcard in MySQL.