### PR TITLE
Install the requests_oauthlib Python dependency

### DIFF
--- a/image/seafile_7.1/Dockerfile
+++ b/image/seafile_7.1/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install --timeout=3600 click termcolor colorlog pymysql \
     django==1.11.29 && rm -r /root/.cache/pip
 
 RUN pip3 install --timeout=3600 Pillow pylibmc captcha jinja2 \
-    sqlalchemy django-pylibmc django-simple-captcha && \
+    sqlalchemy django-pylibmc django-simple-captcha requests_oauthlib && \
     rm -r /root/.cache/pip
 
 


### PR DESCRIPTION
Without this library, OAuth authentication is failing due to missing import.

This was installed through requirements file in the previous versions of this image.