### PR TITLE
Add wait_for_memcached

### DIFF
--- a/scripts_8.0/start.py
+++ b/scripts_8.0/start.py
@@ -15,7 +15,7 @@ import time
 
 from utils import (
     call, get_conf, get_install_dir, get_script, get_command_output,
-    render_template, wait_for_mysql, setup_logging
+    render_template, wait_for_mysql, wait_for_memcached, setup_logging
 )
 from upgrade import check_upgrade
 from bootstrap import init_seafile_server, is_https, init_letsencrypt, generate_local_nginx_conf
@@ -53,6 +53,7 @@ def main():
     call('nginx -s reload')
 
     wait_for_mysql()
+    wait_for_memcached()
     init_seafile_server()
 
     check_upgrade()

--- a/scripts_8.0/utils.py
+++ b/scripts_8.0/utils.py
@@ -17,6 +17,7 @@ import click
 import termcolor
 import colorlog
 import pymysql
+import telnetlib
 
 logger = logging.getLogger('.utils')
 
@@ -279,6 +280,18 @@ def wait_for_mysql():
             time.sleep(2)
             continue
         logdbg('mysql server is ready')
+        return
+
+def wait_for_memcached():
+    while True:
+        try:
+            with telnetlib.Telnet(host='memcached', port=11211, timeout=3) as tn:
+                pass
+        except Exception as e:
+            print ('waiting for memcached to be ready: %s', e)
+            time.sleep(2)
+            continue
+        logdbg('memcached is ready')
         return
 
 def wait_for_nginx():


### PR DESCRIPTION
If the seafile container is started before the memcached container, some error message will be generated in seahub.log.
To avoid this situation, wait for memcached to start before seahub starts.