### PR TITLE
Change nginx configs to also listen for ipv6 requests

### DIFF
--- a/cluster/image/base/services/nginx.conf
+++ b/cluster/image/base/services/nginx.conf
@@ -25,6 +25,7 @@ http {
     include /etc/nginx/sites-enabled/*;
 
     server {
+        listen [::]:80;
         listen 80;
         location / {
             return 444;

--- a/cluster/image/pro_seafile/templates/seafile.nginx.conf.template
+++ b/cluster/image/pro_seafile/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
     rewrite ^ https://{{ domain }}$request_uri? permanent;
@@ -10,6 +11,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -23,6 +25,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 

--- a/cluster/image/pro_seafile_7.1/services/nginx.conf
+++ b/cluster/image/pro_seafile_7.1/services/nginx.conf
@@ -25,6 +25,7 @@ http {
     include /etc/nginx/sites-enabled/*;
 
     server {
+        listen [::]:80;
         listen 80;
         location / {
             return 444;

--- a/cluster/image/pro_seafile_7.1/templates/seafile.nginx.conf.template
+++ b/cluster/image/pro_seafile_7.1/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
     rewrite ^ https://{{ domain }}$request_uri? permanent;
@@ -10,6 +11,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -23,6 +25,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 

--- a/image/base/services/nginx.conf
+++ b/image/base/services/nginx.conf
@@ -26,6 +26,7 @@ http {
     include /etc/nginx/sites-enabled/*;
 
     server {
+        listen [::]:80;
         listen 80;
         location / {
             return 444;

--- a/image/pro_seafile/templates/seafile.nginx.conf.template
+++ b/image/pro_seafile/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
     # allow certbot to connect to challenge location via HTTP Port 80
@@ -19,6 +20,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -32,6 +34,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 

--- a/image/pro_seafile_7.1/services/nginx.conf
+++ b/image/pro_seafile_7.1/services/nginx.conf
@@ -26,6 +26,7 @@ http {
     include /etc/nginx/sites-enabled/*;
 
     server {
+        listen [::]:80;
         listen 80;
         location / {
             return 444;

--- a/image/pro_seafile_7.1/templates/seafile.nginx.conf.template
+++ b/image/pro_seafile_7.1/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
 
@@ -20,6 +21,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -33,6 +35,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 

--- a/image/pro_seafile_8.0/services/nginx.conf
+++ b/image/pro_seafile_8.0/services/nginx.conf
@@ -26,6 +26,7 @@ http {
     include /etc/nginx/sites-enabled/*;
 
     server {
+        listen [::]:80;
         listen 80;
         location / {
             return 444;

--- a/image/pro_seafile_8.0/templates/seafile.nginx.conf.template
+++ b/image/pro_seafile_8.0/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
 
@@ -20,6 +21,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -33,6 +35,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 

--- a/image/seafile/templates/seafile.nginx.conf.template
+++ b/image/seafile/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
 
@@ -20,6 +21,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -33,6 +35,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 

--- a/image/seafile_7.1/services/nginx.conf
+++ b/image/seafile_7.1/services/nginx.conf
@@ -26,6 +26,7 @@ http {
     include /etc/nginx/sites-enabled/*;
 
     server {
+        listen [::]:80;
         listen 80;
         location / {
             return 444;

--- a/image/seafile_7.1/templates/seafile.nginx.conf.template
+++ b/image/seafile_7.1/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
 
@@ -20,6 +21,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -33,6 +35,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 

--- a/image/seafile_8.0/services/nginx.conf
+++ b/image/seafile_8.0/services/nginx.conf
@@ -26,6 +26,7 @@ http {
     include /etc/nginx/sites-enabled/*;
 
     server {
+        listen [::]:80;
         listen 80;
         location / {
             return 444;

--- a/image/seafile_8.0/templates/seafile.nginx.conf.template
+++ b/image/seafile_8.0/templates/seafile.nginx.conf.template
@@ -2,6 +2,7 @@
 # Auto generated at {{ current_timestr }}
 {% if https -%}
 server {
+    listen [::]:80;
     listen 80;
     server_name _ default_server;
 
@@ -20,6 +21,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443;
     listen 443;
     ssl on;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
@@ -33,6 +35,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 


### PR DESCRIPTION
These changes to the nginx config files/templates make IPv6 work.

For IPv6-only setups this solves a more complex problem where you need to initially start the container with Let’s Encrypt disabled because it cannot get the chellenge file due to this missing listen directive in the nginx config. Then you would need to manually change the nginx config which is only generated at the initial start-up and therefore does not include the TLS config.