### PR TITLE
Add support for OAuth and movie thumbnails

### DIFF
--- a/image/seafile_7.1/Dockerfile
+++ b/image/seafile_7.1/Dockerfile
@@ -13,6 +13,9 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get install tzdata -y
 # Nginx
 RUN apt-get install -y nginx
 
+# ffmpeg
+RUN apt-get install -y ffmpeg
+
 # Python3
 RUN apt-get install -y python3 python3-pip python3-setuptools
 RUN python3.6 -m pip install --upgrade pip && rm -r /root/.cache/pip
@@ -24,6 +27,8 @@ RUN pip3 install --timeout=3600 Pillow pylibmc captcha jinja2 \
     sqlalchemy django-pylibmc django-simple-captcha && \
     rm -r /root/.cache/pip
 
+RUN pip3 install --timeout=3600 requests_oauthlib moviepy && \
+    rm -r /root/.cache/pip
 
 # Scripts
 COPY scripts_7.1 /scripts

--- a/image/seafile_8.0/Dockerfile
+++ b/image/seafile_8.0/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get install -y libmemcached11 libmemcached-dev
 # Fuse
 RUN apt-get install -y fuse
 
+# ffmpeg
+RUN apt-get install -y ffmpeg
+
 # Python3
 RUN apt-get install -y python3 python3-pip python3-setuptools
 RUN rm -f /usr/bin/python && ln -s /usr/bin/python3 /usr/bin/python
@@ -34,6 +37,8 @@ RUN pip3 install --timeout=3600 future mysqlclient Pillow pylibmc captcha jinja2
     sqlalchemy django-pylibmc django-simple-captcha pyjwt && \
     rm -r /root/.cache/pip
 
+RUN pip3 install --timeout=3600 requests_oauthlib moviepy && \
+    rm -r /root/.cache/pip
 
 # Scripts
 COPY scripts_8.0 /scripts

--- a/image/seafile_9.0/Dockerfile
+++ b/image/seafile_9.0/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get install -y libmemcached11 libmemcached-dev
 # Fuse
 RUN apt-get install -y fuse
 
+# ffmpeg
+RUN apt-get install -y ffmpeg
+
 # Ldap
 RUN apt-get install -y ldap-utils ca-certificates
 RUN echo "TLS_REQCERT     allow" >> /etc/ldap/ldap.conf
@@ -38,6 +41,8 @@ RUN pip3 install --timeout=3600 future mysqlclient Pillow pylibmc captcha jinja2
     sqlalchemy django-pylibmc django-simple-captcha pyjwt pycryptodome==3.12.0 -i https://mirrors.aliyun.com/pypi/simple && \
     rm -r /root/.cache/pip
 
+RUN pip3 install --timeout=3600 requests_oauthlib moviepy && \
+    rm -r /root/.cache/pip
 
 # Scripts
 COPY scripts_9.0 /scripts


### PR DESCRIPTION
Superseedes #218 (since that only fixes 7.1). Fixes #212.
Also added ffmpeg and moviepy to allow for movie thumbnails as per https://manual.seafile.com/deploy/video_thumbnails/