### PR TITLE
Improving Git protocol

### DIFF
--- a/cluster/image/pro_seafile/scripts/ssl.sh
+++ b/cluster/image/pro_seafile/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/cluster/image/pro_seafile_7.1/scripts_7.1/ssl.sh
+++ b/cluster/image/pro_seafile_7.1/scripts_7.1/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/cluster/scripts/ssl.sh
+++ b/cluster/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts/ssl.sh
+++ b/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts_7.1/ssl.sh
+++ b/scripts_7.1/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts_8.0/ssl.sh
+++ b/scripts_8.0/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts_9.0/ssl.sh
+++ b/scripts_9.0/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master


### PR DESCRIPTION
March 15, 2022 Github permanently stop accepting DSA keys.
The deprecated MACs, ciphers, and unencrypted Git protocol has been permanently disabled. 
https://github.blog/2021-09-01-improving-git-protocol-security-github/