### PR TITLE
Shallow clone diafygi/acme-tiny to resolve init timeout failure

### DIFF
--- a/cluster/image/pro_seafile/scripts/ssl.sh
+++ b/cluster/image/pro_seafile/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone --depth=1 git://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/cluster/image/pro_seafile_7.1/scripts_7.1/ssl.sh
+++ b/cluster/image/pro_seafile_7.1/scripts_7.1/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone --depth=1 git://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/cluster/scripts/ssl.sh
+++ b/cluster/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone --depth=1 git://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts/ssl.sh
+++ b/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone --depth=1 git://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts_7.1/ssl.sh
+++ b/scripts_7.1/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone --depth=1 git://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts_8.0/ssl.sh
+++ b/scripts_8.0/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone --depth=1 git://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master


### PR DESCRIPTION
Initialization was failing on my machine (GCP Compute Engine, e2-micro). Since my machine was so slow, git was timing out when cloning the acme-tiny repo. Since only the script is needed, this change will pull only the most recent commit instead.