### PR TITLE
Fix cloning acme-tiny due to Github disabling git:// protocol

### DIFF
--- a/scripts/ssl.sh
+++ b/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git://github.com/diafygi/acme-tiny.git $letsencryptdir
+    git clone git@github.com:diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master

--- a/scripts/ssl.sh
+++ b/scripts/ssl.sh
@@ -17,7 +17,7 @@ mkdir -p /var/www/challenges && chmod -R 777 /var/www/challenges
 mkdir -p $ssldir
 
 if ! [[ -d $letsencryptdir ]]; then
-    git clone git@github.com:diafygi/acme-tiny.git $letsencryptdir
+    git clone https://github.com/diafygi/acme-tiny.git $letsencryptdir
 else
     cd $letsencryptdir
     git pull origin master:master


### PR DESCRIPTION
fixed error "The unauthenticated git protocol on port 9418 is no longer supported"; 

see https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git