### PR TITLE
Adding "pip install cryptography" to fix startup error

### DIFF
--- a/image/seafile_9.0/Dockerfile
+++ b/image/seafile_9.0/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y python3 python3-pip python3-setuptools && \
     python3 -m pip install --upgrade pip -i https://mirrors.aliyun.com/pypi/simple && rm -r /root/.cache/pip
 
 RUN pip3 install --timeout=3600 click termcolor colorlog pymysql django==3.2.* \
-    future mysqlclient Pillow pylibmc captcha markupsafe==2.0.1 jinja2 \
+    future mysqlclient Pillow pylibmc captcha markupsafe==2.0.1 jinja2 cryptography \
     sqlalchemy django-pylibmc django-simple-captcha pyjwt pycryptodome==3.12.0 psd-tools \
     -i https://mirrors.aliyun.com/pypi/simple && rm -r /root/.cache/pip
 


### PR DESCRIPTION
Without this line, the logs are full of `waiting for mysql server to be ready: %s 'cryptography' package is required for sha256_password or caching_sha2_password auth methods` and the Docker container seafileltd/seafile-mc:latest` never start.