### PR TITLE
Allow recreation configuration files

### DIFF
--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -107,7 +107,7 @@ def parse_args():
 
 def init_seafile_server():
     version_stamp_file = get_version_stamp_file()
-    if exists(join(shared_seafiledir, 'seafile-data')):
+    if exists(join(topdir, 'conf')):
         if not exists(version_stamp_file):
             update_version_stamp(os.environ['SEAFILE_VERSION'])
         # sysbol link unlink after docker finish.
@@ -115,7 +115,7 @@ def init_seafile_server():
         current_version_dir='/opt/seafile/' + get_conf('SEAFILE_SERVER', 'seafile-server') + '-' +  read_version_stamp()
         if not exists(latest_version_dir):
             call('ln -sf ' + current_version_dir + ' ' + latest_version_dir)
-        loginfo('Skip running setup-seafile-mysql.py because there is existing seafile-data folder.')
+        loginfo('Skip running setup-seafile-mysql.py because there is existing conf folder.')
         return
 
     loginfo('Now running setup-seafile-mysql.py in auto mode.')


### PR DESCRIPTION
(Re)creation of configuration files now depend on existence of `seafile-data` folder. However, one could still have this folder but miss the configurations. Checking for the right folder makes Seafile more resilient against data availability issues, but also allows for container users to force recreation of the configurations on demand.

This commit allows re-installing the container end keeping the data. It provides a way to separate user data from recreatable configurations. So one does not need to delete everything and re-upload all the data to get new configuration, see (e.g. [mentioned here](https://forum.seafile.com/t/seafile-wont-start-after-recreating-docker-image/15075/2)).

The environment variables are only relevant for the first deployment. Existing configuration in the volumes is not overwritten. After this PR, one can regenerate configurations by deleting `seafile-data/seafile/conf`. It is helpful in scenarios where docker-compose variables are updated frequently, e.g. by using CI/CD. This way, docker-compose configurations will stay in sync with the configurations inside the container.

The similar behavior already exists when `seafile-data/nginx` folder is deleted, then recreates the folder regardless of `seafile-data` exists or not.