### PR TITLE
Allow specifying FILE_SERVER_ROOT

### DIFF
--- a/scripts_9.0/bootstrap.py
+++ b/scripts_9.0/bootstrap.py
@@ -118,6 +118,14 @@ def parse_args():
 
     return ap.parse_args()
 
+def get_file_server_root():
+    file_server_root = get_conf('FILE_SERVER_ROOT')
+    if not file_server_root:
+        domain = get_conf('SEAFILE_SERVER_HOSTNAME', 'seafile.example.com')
+        proto = 'https' if is_https() else 'http'
+        file_server_root = '{proto}://{domain}/seafhttp'.format(proto=proto, domain=domain)
+    return file_server_root
+
 def init_seafile_server():
     version_stamp_file = get_version_stamp_file()
     if exists(join(shared_seafiledir, 'seafile-data')):
@@ -157,8 +165,6 @@ def init_seafile_server():
     setup_script = get_script('setup-seafile-mysql.sh')
     call('{} auto -n seafile'.format(setup_script), env=env)
 
-    domain = get_conf('SEAFILE_SERVER_HOSTNAME', 'seafile.example.com')
-    proto = 'https' if is_https() else 'http'
     with open(join(topdir, 'conf', 'seahub_settings.py'), 'a+') as fp:
         fp.write('\n')
         fp.write("""CACHES = {
@@ -174,7 +180,7 @@ COMPRESS_CACHE_BACKEND = 'locmem'""")
         fp.write('\n')
         fp.write("TIME_ZONE = '{time_zone}'".format(time_zone=os.getenv('TIME_ZONE',default='Etc/UTC')))
         fp.write('\n')
-        fp.write('FILE_SERVER_ROOT = "{proto}://{domain}/seafhttp"'.format(proto=proto, domain=domain))
+        fp.write('FILE_SERVER_ROOT = "{file_server_root}"'.format(file_server_root=get_file_server_root()))
         fp.write('\n')
 
     # Disabled the Elasticsearch process on Seafile-container


### PR DESCRIPTION
This is backward compatible feature that allow configuring FILE_SERVER_ROOT variable.

It allows Seafile Docker (without Lets Encrypt) + TLS proxy (such as reverse proxy, Web Application Firewall or Application Gateway) configuration which was not possible before.

Before, without specifying this variable, if Let's Encrypt is disabled (i.e., SEAFILE_SERVER_LETSENCRYPT=false) then FILE_SERVER_ROOT is always set to `http://` protocol. However, if the user wishes to run the container on HTTP mode but have another proxy over HTTPs, it does not work due to the hardcoded http:// protocol.

After this commit, the user can override FILE_SERVER_ROOT and this way run the docker in HTTP mode meanwhile serving the docker container over a custom HTTPS proxy.