### PR TITLE
Add: enable .well-known/acme-challenge when https

### DIFF
--- a/image/seafile_9.0/templates/seafile.nginx.conf.template
+++ b/image/seafile_9.0/templates/seafile.nginx.conf.template
@@ -85,9 +85,11 @@ server {
         root /opt/seafile/seafile-server-latest/seahub;
     }
 
+{% if https -%}
     # For letsencrypt
     location /.well-known/acme-challenge/ {
         alias /var/www/challenges/;
         try_files $uri =404;
     }
+{% endif -%}
 }


### PR DESCRIPTION
Hello,

I've added a small change for the NGINX template:

Enable the NGINX route .well-known/acme-challenge only,
when using LetsEncrypt and activating HTTPS-protocol.

Why?

When using an external reverse proxy which is terminating TLS and itself is using
LetsEncrypt with a http based challenge it gets in conflict with the NGINX running in the container.
It looks like the containers NGINX will get the traffic before the proxy in front of it.

Additionally when running the container with http only, this would unnecessary
increase the NGINX configuration in a confusing way.