### PR TITLE
Create nginx log directory

### DIFF
--- a/scripts/scripts_11.0/create_data_links.sh
+++ b/scripts/scripts_11.0/create_data_links.sh
@@ -45,6 +45,7 @@ if [[ ! -e /shared/logs/var-log ]]; then
     mkdir -p /shared/logs/ && mv /var/log /shared/logs/var-log
 fi
 rm -rf /var/log && ln -sf /shared/logs/var-log /var/log
+mkdir -p /shared/logs/var-log/nginx
 
 mkdir -p /shared/nginx/conf/
 


### PR DESCRIPTION
When restoring from backup which strips `logs` directories, startup failes with
```
nginx: [alert] could not open error log file: open() "/var/log/nginx/error.log" failed (2: No such file or directory)
```

This change should also handle this case gracefully.