### PR TITLE
Fix MYSQL_PORT

### DIFF
--- a/scripts/scripts_11.0/bootstrap.py
+++ b/scripts/scripts_11.0/bootstrap.py
@@ -146,7 +146,7 @@ def init_seafile_server():
         'MYSQL_USER_PASSWD': str(uuid.uuid4()),
         'MYSQL_USER_HOST': '%.%.%.%',
         'MYSQL_HOST': get_conf('DB_HOST', '127.0.0.1'),
-        'MYSQL_PORT': int(get_conf('DB_PORT', 3306)),
+        'MYSQL_PORT': get_conf('DB_PORT', '3306'),
         # Default MariaDB root user has empty password and can only connect from localhost.
         'MYSQL_ROOT_PASSWD': get_conf('DB_ROOT_PASSWD', ''),
     }


### PR DESCRIPTION
I've got following error when trying to set up this container:

```
seafile-1  | Traceback (most recent call last):
seafile-1  |   File "/scripts/start.py", line 95, in <module>
seafile-1  |     main()
seafile-1  |   File "/scripts/start.py", line 59, in main
seafile-1  |     init_seafile_server()
seafile-1  |   File "/scripts/bootstrap.py", line 166, in init_seafile_server
seafile-1  |     call('{} auto -n seafile'.format(setup_script), env=env)
seafile-1  |   File "/scripts/utils.py", line 70, in call
seafile-1  |     return subprocess.check_call(*a, **kw)
seafile-1  |   File "/usr/lib/python3.10/subprocess.py", line 364, in check_call
seafile-1  |     retcode = call(*popenargs, **kwargs)
seafile-1  |   File "/usr/lib/python3.10/subprocess.py", line 345, in call
seafile-1  |     with Popen(*popenargs, **kwargs) as p:
seafile-1  |   File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
seafile-1  |     self._execute_child(args, executable, preexec_fn, close_fds,
seafile-1  |   File "/usr/lib/python3.10/subprocess.py", line 1783, in _execute_child
seafile-1  |     env_list.append(k + b'=' + os.fsencode(v))
seafile-1  |   File "/usr/lib/python3.10/os.py", line 811, in fsencode
seafile-1  |     filename = fspath(filename)  # Does type-checking of `filename`.
seafile-1  | TypeError: expected str, bytes or os.PathLike object, not int
```

For some reason MYSQL_PORT was cast to int.