### PR TITLE
Activate ipv6 in nginx by default

### DIFF
--- a/templates/seafile.nginx.conf.template
+++ b/templates/seafile.nginx.conf.template
@@ -20,6 +20,7 @@ server {
 
 server {
 {% if https -%}
+    listen [::]:443 ssl;
     listen 443 ssl;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
     ssl_certificate_key  /shared/ssl/{{ domain }}.key;
@@ -32,6 +33,7 @@ server {
     # ssl_session_cache shared:SSL:10m;
     # ssl_session_timeout 10m;
 {% else -%}
+    listen [::]:80;
     listen 80;
 {% endif -%}
 


### PR DESCRIPTION
Currently, the seafile.nginx.conf.template only listen on ipv4.  Why not activing ipv6 by default.