### PR TITLE
Only set X-Forwarded-Proto when header not set

### DIFF
--- a/templates/seafile.nginx.conf.template
+++ b/templates/seafile.nginx.conf.template
@@ -45,7 +45,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header Forwarded "for=$remote_addr;proto=$scheme";
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $x_forwarded_proto;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Connection "";
         proxy_http_version 1.1;
@@ -88,7 +88,7 @@ server {
         proxy_set_header   X-Real-IP $remote_addr;
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Host $server_name;
-        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   X-Forwarded-Proto $x_forwarded_proto;
         proxy_read_timeout  1200s;
         client_max_body_size 0;
 
@@ -107,4 +107,9 @@ server {
         try_files $uri =404;
     }
 {% endif -%}
+}
+
+map $http_x_forwarded_proto $x_forwarded_proto {
+    ""      $scheme;
+    default $http_x_forwarded_proto;
 }


### PR DESCRIPTION
When the seafile docker container
is behind a proxy that does the TLS termination,
such that the seafile docker sees HTTP only,
then, it receives requests
where the following headers are set in the following way:

    X-Forwarded-Proto: https
    X-Forwarded-Ssl: on

Because the default NGINX template has this directive:

    proxy_set_header X-Forwarded-Proto $scheme

the request gets transmitted to gunicorn with the following, contradictory values:

    X-Forwarded-Proto: http
    X-Forwarded-Ssl: on

Thus Seafile rejects the requests
with a "Contradictory scheme headers" error.

We instead change the header only when it is not set.

Fixes #226.