### PR TITLE
fix: close root connection only when used to fix #452

### DIFF
--- a/scripts/scripts_12.0/setup-seafile-mysql.py
+++ b/scripts/scripts_12.0/setup-seafile-mysql.py
@@ -1637,7 +1637,8 @@ def main():
 
     report_success()
 
-    db_config.root_conn.close()
+    if db_config.root_conn:
+        db_config.root_conn.close()
 
 def report_success():
     message = '''\

--- a/scripts/scripts_13.0/setup-seafile-mysql.py
+++ b/scripts/scripts_13.0/setup-seafile-mysql.py
@@ -1621,7 +1621,8 @@ def main():
 
     report_success()
 
-    db_config.root_conn.close()
+    if db_config.root_conn:
+        db_config.root_conn.close()
 
 def report_success():
     message = '''\


### PR DESCRIPTION
As it states on the tin, prevents error when using the `--use-existing-db` feature.