### PR TITLE
feat: allow for passing environment variables to setup-seafile-mysql from container

### DIFF
--- a/scripts/scripts_12.0/bootstrap.py
+++ b/scripts/scripts_12.0/bootstrap.py
@@ -150,6 +150,7 @@ def init_seafile_server():
         # Default MariaDB root user has empty password and can only connect from localhost.
         'MYSQL_ROOT_PASSWD': get_conf('DB_ROOT_PASSWD', ''),
     }
+    env.update(os.environ) # Allows additional configuration settings in setup-seafile-mysql.py via environment variables.
 
     setup_script = get_script('setup-seafile-mysql.sh')
     call('{} auto -n seafile'.format(setup_script), env=env)

--- a/scripts/scripts_13.0/bootstrap.py
+++ b/scripts/scripts_13.0/bootstrap.py
@@ -150,6 +150,7 @@ def init_seafile_server():
         # Default MariaDB root user has empty password and can only connect from localhost.
         'MYSQL_ROOT_PASSWD': get_conf('INIT_SEAFILE_MYSQL_ROOT_PASSWORD', ''),
     }
+    env.update(os.environ) # Allows additional configuration settings in setup-seafile-mysql.py via environment variables.
 
     setup_script = get_script('setup-seafile-mysql.sh')
     call('{} auto -n seafile'.format(setup_script), env=env)


### PR DESCRIPTION
One problem I was facing is that I wanted to use pre-existing databases and preferable in a rootless setup. This is fully supported via `setup-seafile-mysql.py` by providing additional environment variables like `USE_EXISTING_DB`, `CCNET_DB` and more environment variables.

However, because there was "some" mapping happening a custom environment dict was provided in the Python subprocess call which fully overwrites the default environment variables.
https://github.com/haiwen/seafile-docker/blob/414c6b6ca94e3bbbbf24369cad960a29be49f38b/scripts/scripts_12.0/bootstrap.py#L141-L155

This prevents end users from customizing the setup script from their containers. Hence, I added a line that updates the passed environment dict with the current environment to allow end users from customizing the setup behavior. **This is fully backwards compatible!**

NOTE: In Seafile versions 12 and 13 new environment variables are introduced in Seahub to allow "dynamically" configuring database connections. As these are **NOT** used in the setup script it is impossible to use these together with setup. This change also allows end-users to workaround this issue by passing `CCNET_DB` environment variables.
```python
    ## For dtable_db
    _rewrite_db_env_key_map = {
        'HOST': 'SEAFILE_MYSQL_DB_HOST',
        'PORT': 'SEAFILE_MYSQL_DB_PORT',
        'USER': 'SEAFILE_MYSQL_DB_USER',
        'PASSWORD': 'SEAFILE_MYSQL_DB_PASSWORD',
        'NAME': 'SEAFILE_MYSQL_DB_SEAHUB_DB_NAME'
    }

    for db_key, env_key in _rewrite_db_env_key_map.items():
        if env_value := os.environ.get(env_key):
            DATABASES['default'][db_key] = env_value

```
https://github.com/haiwen/seahub/blob/a150586d3464308eb41f2d12420bb61a4c9de2ad/seahub/settings.py#L1195-L1207