### PR TITLE
Fix Seafdav: WebDAV MOVE command causing 502

### DIFF
--- a/services/seafile.nginx.conf
+++ b/services/seafile.nginx.conf
@@ -1,3 +1,8 @@
+map $http_destination $nossl_destination {
+    "~^https:(.+)$" $1;
+    "~^http:(.+)$" $1;
+}
+
 server {
     listen 80;
 
@@ -40,6 +45,7 @@ server {
         proxy_set_header   X-Real-IP $remote_addr;
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_set_header   Destination "http:$nossl_destination";
         proxy_read_timeout  1200s;
         client_max_body_size 0;
 


### PR DESCRIPTION
When using Seafdav, probably when updating an existing file, the WebDAV client will perform a PUT to a temporary file, then a MOVE to replace the destination file. The MOVE operation fails after passing through a reverse proxy with SSL termination.

```
==> /var/log/nginx/seafdav.access.log <==
192.168.100.137 10.42.2.33 [22/Oct/2025:13:47:04 +0700] "PUT /seafdav/mylib/file.txt.tmp.18881965 HTTP/1.1" 401 139 "-" "okhttp/4.12.0" 0.001
192.168.100.137 10.42.1.98 [22/Oct/2025:13:47:07 +0700] "PUT /seafdav/mylib/file.txt.tmp.18881965 HTTP/1.1" 201 372 "-" "okhttp/4.12.0" 1.993
192.168.100.137 10.42.3.74 [22/Oct/2025:13:47:07 +0700] "MOVE /seafdav/mylib/file.txt.tmp.18881965 HTTP/1.1" 401 139 "-" "okhttp/4.12.0" 0.001
192.168.100.137 10.42.4.98 [22/Oct/2025:13:47:07 +0700] "MOVE /seafdav/mylib/file.txt.tmp.18881965 HTTP/1.1" 502 588 "-" "okhttp/4.12.0" 0.044

```

Solution: remove https from the Destination header.

See https://forum.seafile.com/t/seafdav-move-command-causing-502/11582/25