### PR TITLE
Fix: Add IPv6 listen directives to nginx template

### DIFF
--- a/templates/seafile.nginx.conf.template
+++ b/templates/seafile.nginx.conf.template
@@ -3,6 +3,7 @@
 {% if https -%}
 server {
     listen 80;
+    listen [::]:80;
     server_name _ default_server;
 
     # allow certbot to connect to challenge location via HTTP Port 80
@@ -21,6 +22,7 @@ server {
 server {
 {% if https -%}
     listen 443 ssl;
+    listen [::]:443 ssl;
     ssl_certificate      /shared/ssl/{{ domain }}.crt;
     ssl_certificate_key  /shared/ssl/{{ domain }}.key;
 
@@ -33,6 +35,7 @@ server {
     # ssl_session_timeout 10m;
 {% else -%}
     listen 80;
+    listen [::]:80;
 {% endif -%}
 
     server_name {{ domain }};


### PR DESCRIPTION
## Problem
The nginx configuration template only listens on IPv4 addresses, which causes "Connection refused" errors when accessing the seafile container via IPv6 addresses in Docker networks.

**Error observed:**
```
connect() failed (111: Connection refused) while connecting to upstream, 
upstream: "http://[fd00:192:168:1::3]:80/..."
```

## Root Cause
The template only includes `listen 80;` and `listen 443 ssl;` which only bind to IPv4 addresses. In Docker networks with IPv6 enabled, containers may be accessed via IPv6 addresses, causing connection failures.

## Solution
Add IPv6 listen directives to all server blocks:
- `listen [::]:80;` for HTTP
- `listen [::]:443 ssl;` for HTTPS

## Changes
- Added `listen [::]:80;` to the HTTP redirect server block (for HTTPS mode)
- Added `listen [::]:443 ssl;` to the HTTPS server block
- Added `listen [::]:80;` to the HTTP server block (for non-HTTPS mode)

## Testing
- [x] IPv6 connections now work correctly
- [x] IPv4 connections continue to work (backward compatible)
- [x] Both HTTP and HTTPS modes support IPv6