### PR TITLE
Remove stale PID files on container startup

### DIFF
--- a/scripts/scripts_13.0/enterpoint.sh
+++ b/scripts/scripts_13.0/enterpoint.sh
@@ -9,6 +9,15 @@ function log() {
 }
 
 
+# remove stale pid files
+PIDS_DIR=/opt/seafile/pids
+
+if [ -d "$PIDS_DIR" ]; then
+    log "Removing any existing stale pid files."
+    rm -fv $PIDS_DIR/*.pid
+fi
+
+
 # check nginx
 while [ 1 ]; do
     process_num=$(ps -ef | grep "/usr/sbin/nginx" | grep -v "grep" | wc -l)


### PR DESCRIPTION
Recently the  `seafdav` service in my Seafile container stopped working and restarts didn't help.

Examining `seafile-monitor.log` revealed that this is caused by a stale pid file:
```
[2026-03-29 20:26:02] Start wsgidav.server.server_cli
[2026-03-29 20:26:03 +0200] [233516] [INFO] Starting gunicorn 23.0.0

Error: Already running on PID 201 (or pid file '/opt/seafile/pids/seafdav.pid' is stale)
```

The proposed fix in this PR adds the following changes to `enterpoint.sh`:
- check for the existence of the `/opt/seafile/pids` directory on container startup
- remove any stale pid files within that directory (being verbose with `-v` to show their names)

Please note that I only modified the code for Seafile 13 CE for now by intention, to ease the review.

While this is a very simple solution, perhaps it's also the best future-proof approach: These files could also stick around due to process crashes and the general assumption on container startup is a fresh pid-free directory anyway.

This also fixes issue #481 which occasionally affected me as well.