### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ If you are not familiar with docker commands, please refer to [docker documentat
 ## Getting Started
 
 Please refer to the [Deploy Documentation](https://manual.seafile.com/latest/setup/overview/).
+
+If you would rather not run a server yourself, Seafile can also be deployed as a managed instance:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/seafile)


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Seafile to our marketplace, so this PR adds a small "Deploy with Zenith" badge under Getting Started (links to https://zenith.hosting/host/seafile).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

docs-only change, no code touched, so there is nothing to test or build.